### PR TITLE
fix(deps): remove unused recharts, move dev deps to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,20 +3,21 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "lucide-react": "^0.483.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-scripts": "5.0.1",
+    "tailwindcss": "^4.0.15",
+    "web-vitals": "^2.1.4"
+  },
+  "devDependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^13.5.0",
     "autoprefixer": "^10.4.21",
     "http-proxy-middleware": "^3.0.3",
-    "lucide-react": "^0.483.0",
-    "postcss": "^8.5.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-scripts": "5.0.1",
-    "recharts": "^2.15.1",
-    "tailwindcss": "^4.0.15",
-    "web-vitals": "^2.1.4"
+    "postcss": "^8.5.3"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
## Summary

- **Remove `recharts`**: listed in `package.json` but never imported in any source file — dead dependency inflating the install footprint
- **Move dev-only packages to `devDependencies`**: `@testing-library/*`, `autoprefixer`, `http-proxy-middleware`, and `postcss` are only needed during development/testing and should not be listed as production dependencies

## Test plan
- [ ] `npm install` succeeds
- [ ] `npm run build` produces a clean production build
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)