### PR TITLE
fix(save): persist saves to localStorage, guard loadGame bounds

### DIFF
--- a/src/RetroRPG.js
+++ b/src/RetroRPG.js
@@ -57,7 +57,13 @@ const RetroRPG = () => {
   const [libraryOpen, setLibraryOpen] = useState(false);
   const [innOptions, setInnOptions] = useState(true);
   const [gameTime, setGameTime] = useState(0);
-  const [saveGames, setSaveGames] = useState([]);
+  const [saveGames, setSaveGames] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('retrorpg_saves')) || [];
+    } catch {
+      return [];
+    }
+  });
   
   // Images for different scenes
   const sceneImages = {
@@ -792,14 +798,16 @@ const RetroRPG = () => {
     
     const newSaveGames = [...saveGames, saveData];
     setSaveGames(newSaveGames);
-    
+    localStorage.setItem('retrorpg_saves', JSON.stringify(newSaveGames));
+
     addToGameLog('Game saved successfully!');
   };
   
   // Load game
   const loadGame = (index) => {
     const saveData = saveGames[index];
-    
+    if (!saveData) return;
+
     setPlayer(saveData.player);
     setGameMap(saveData.gameMap);
     setPlayerPosition(saveData.playerPosition);


### PR DESCRIPTION
## Summary
- **Save game lost on refresh** (watts4/retrorpg#2): `saveGame()` was updating React state but never writing to `localStorage`, so saves disappeared on page reload. Now writes `retrorpg_saves` to `localStorage` on every save and initializes state from it on mount.
- **`loadGame()` crash on bad index**: `saveGames[index]` could be `undefined` if called with an out-of-range index, causing an uncaught TypeError that crashes the game. Added an early `return` guard.

## Test plan
- [ ] Save a game, refresh the page — saved game should still appear in the load list
- [ ] Saved games survive multiple saves and loads across sessions
- [ ] No runtime errors when load is called with a stale index

🤖 Generated with [Claude Code](https://claude.com/claude-code)