### PR TITLE
fix: remove unused MapPin and Book imports from lucide-react

### DIFF
--- a/src/RetroRPG.js
+++ b/src/RetroRPG.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { MapPin, Sword, Shield, Book, Coins, Heart, Clock, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, Home } from 'lucide-react';
+import { Sword, Shield, Coins, Heart, Clock, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, Home } from 'lucide-react';
 
 // Game constants
 const TILE_TYPES = {


### PR DESCRIPTION
## Summary
- `MapPin` and `Book` were imported from `lucide-react` at `RetroRPG.js:2` but never used anywhere in the component tree — confirmed by searching all `src/` files.
- Removing dead imports reduces the chance of confusion and keeps the bundle analyzer clean (tree-shaking already excludes them, so no bundle-size change).

## Test plan
- [ ] `npm run build` completes without errors or warnings about these icons
- [ ] All game UI renders correctly — no missing icon references

🤖 Generated with [Claude Code](https://claude.com/claude-code)