### PR TITLE
fix: small cleanups (broken test, duplicate import, indentation)

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Mystic Realms title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const titleElement = screen.getByRole('heading', { name: /Mystic Realms/i });
+  expect(titleElement).toBeInTheDocument();
 });

--- a/src/RetroRPG.js
+++ b/src/RetroRPG.js
@@ -671,7 +671,7 @@ const RetroRPG = () => {
   
   // Open shop
   const openShop = () => {
-	    setShopOpen(true);
+    setShopOpen(true);
     setLibraryOpen(false);
     setInnOptions(false);
     addToGameLog('Welcome to the shop! What would you like to buy?');

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import './index.css';
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- Replace the leftover CRA boilerplate test in App.test.js (asserting on "learn react" text that doesn't exist) with one that asserts the real "Mystic Realms" header.
- Drop duplicate `import './index.css'` in src/index.js.
- Fix a stray tab on the first line of `openShop` in RetroRPG.js.

## Test plan
- [x] `npx react-scripts test --watchAll=false` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)