### PR TITLE
fix(shop): don't downgrade equipped gear when buying weaker items (closes #9)

### DIFF
--- a/src/RetroRPG.js
+++ b/src/RetroRPG.js
@@ -703,18 +703,30 @@ const RetroRPG = () => {
       newInventory.push({ ...item });
     }
     
+    // Auto-equip weapons/armor only when the slot is empty OR the new item is
+    // a strict upgrade. A weaker purchase goes into inventory and the player
+    // keeps wielding what they had.
     let attackBonus = 0;
     let defenseBonus = 0;
+    let didEquip = false;
     const newEquipment = { ...player.equipment };
 
     if (item.type === 'weapon') {
-      if (newEquipment.weapon) attackBonus -= newEquipment.weapon.attack || 0;
-      newEquipment.weapon = item;
-      attackBonus += item.attack || 0;
+      const currentAttack = newEquipment.weapon ? (newEquipment.weapon.attack || 0) : 0;
+      const newAttack = item.attack || 0;
+      if (!newEquipment.weapon || newAttack > currentAttack) {
+        attackBonus = newAttack - currentAttack;
+        newEquipment.weapon = item;
+        didEquip = true;
+      }
     } else if (item.type === 'armor') {
-      if (newEquipment.armor) defenseBonus -= newEquipment.armor.defense || 0;
-      newEquipment.armor = item;
-      defenseBonus += item.defense || 0;
+      const currentDefense = newEquipment.armor ? (newEquipment.armor.defense || 0) : 0;
+      const newDefense = item.defense || 0;
+      if (!newEquipment.armor || newDefense > currentDefense) {
+        defenseBonus = newDefense - currentDefense;
+        newEquipment.armor = item;
+        didEquip = true;
+      }
     }
 
     setPlayer(prev => ({
@@ -726,8 +738,11 @@ const RetroRPG = () => {
       defense: prev.defense + defenseBonus
     }));
 
-    const equipped = item.type === 'weapon' || item.type === 'armor' ? ' and equipped it' : '';
-    addToGameLog(`You bought a ${item.name} for ${item.price} gold${equipped}.`);
+    let suffix = '';
+    if (item.type === 'weapon' || item.type === 'armor') {
+      suffix = didEquip ? ' and equipped it' : ' (kept in inventory; your current gear is stronger)';
+    }
+    addToGameLog(`You bought a ${item.name} for ${item.price} gold${suffix}.`);
   };
   
   // Open library


### PR DESCRIPTION
## Summary

Fixes the silent downgrade described in #9: buying a Wooden Sword after wielding an Iron Sword stopped your attack at 3 instead of 7, with no warning and no UI to recover.

The change auto-equips on purchase only when:
- the slot is empty, OR
- the new item is a strict upgrade (higher attack for weapons, higher defense for armor).

Otherwise the new item goes into inventory and the existing gear stays equipped. The game log now says either *"and equipped it"* or *"(kept in inventory; your current gear is stronger)"* so the player knows what happened.

## What changed

`src/RetroRPG.js` — the `buyItem` weapon/armor branch. No new files, no API changes, no save-format changes.

## Test plan

- [x] `npm run build` succeeds
- [ ] Play test: buy a weaker weapon while equipped — gear stays, log says "kept in inventory"
- [ ] Play test: buy a stronger weapon while equipped — gear swaps, log says "equipped it", attack delta is correct
- [ ] Play test: buy a weapon when slot is empty — gets equipped
- [ ] Same three for armor

Closes #9