### PR TITLE
fix: cap save slots at 5 and trim game log to 50 entries (closes #10)

### DIFF
--- a/src/RetroRPG.js
+++ b/src/RetroRPG.js
@@ -800,7 +800,9 @@ const RetroRPG = () => {
     addToGameLog('You rest at the inn and recover all your HP.');
   };
   
-  // Save game
+  // Save game — cap at MAX_SAVE_SLOTS, dropping the oldest when full so
+  // localStorage doesn't accumulate every session forever.
+  const MAX_SAVE_SLOTS = 5;
   const saveGame = () => {
     const saveData = {
       player,
@@ -810,12 +812,16 @@ const RetroRPG = () => {
       gameTime,
       timestamp: new Date().toLocaleString()
     };
-    
-    const newSaveGames = [...saveGames, saveData];
+
+    const appended = [...saveGames, saveData];
+    const newSaveGames = appended.slice(-MAX_SAVE_SLOTS);
     setSaveGames(newSaveGames);
     localStorage.setItem('retrorpg_saves', JSON.stringify(newSaveGames));
 
-    addToGameLog('Game saved successfully!');
+    const droppedOldest = appended.length > MAX_SAVE_SLOTS;
+    addToGameLog(droppedOldest
+      ? `Game saved successfully (oldest save dropped; ${MAX_SAVE_SLOTS} slot cap).`
+      : 'Game saved successfully!');
   };
   
   // Load game
@@ -1070,9 +1076,14 @@ const RetroRPG = () => {
     returnToInn();
   };
   
-  // Add to game log
+  // Add to game log — trim to the last MAX_LOG_ENTRIES so memory doesn't grow
+  // without bound (only the most recent ~10 are rendered anyway).
+  const MAX_LOG_ENTRIES = 50;
   const addToGameLog = (message) => {
-    setGameLog(prev => [...prev, message]);
+    setGameLog(prev => {
+      const next = [...prev, message];
+      return next.length > MAX_LOG_ENTRIES ? next.slice(-MAX_LOG_ENTRIES) : next;
+    });
   };
   
   return (


### PR DESCRIPTION
## Summary

Two unbounded growth fixes per #10:

**Save slots** — `saveGame()` now caps `retrorpg_saves` at 5 entries. When full, the oldest save is dropped on the next save (FIFO). The shop log message tells the player when this happens. No save-file format change; older saves continue to load.

**Game log** — `addToGameLog()` now trims `gameLog` state to the last 50 entries. Only the last ~10 are rendered anyway, so this is invisible in normal play and bounds memory after long sessions.

## What changed

`src/RetroRPG.js` — `saveGame` and `addToGameLog`. Two new local constants (`MAX_SAVE_SLOTS = 5`, `MAX_LOG_ENTRIES = 50`).

## Test plan

- [x] `npm run build` succeeds
- [ ] Play test: save 6 times — confirm oldest save is dropped on the 6th save and log message indicates the drop
- [ ] Play test: existing pre-cap saves in localStorage continue to load
- [ ] Play test: nothing visually changes about the rendered log

Closes #10